### PR TITLE
Album genre schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,5 @@
+-- Genre table
+CREATE TABLE genre(
+	id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	name VARCHAR(255)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -3,3 +3,14 @@ CREATE TABLE genre(
 	id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
 	name VARCHAR(255)
 );
+
+-- Music Album table
+CREATE TABLE music_albums (
+	id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	release_date DATE,
+	album_title VARCHAR(255),
+	album_artist VARCHAR(255),
+	on_spotify BOOL
+  genre_id INT
+  ADD CONSTRAINT fk_genre FOREIGN KEY (genre_id) REFERENCES genre(id)
+);


### PR DESCRIPTION
This PR introduces to the development branch `schema.sql` which contains the commands to create `SQL` database tables for Music Albums and Genres with a many-to-1 relationship between the two (many albums can have the same genre). This relationship is implemented through a `genre_id` column in the music table that contains foreign keys that reference the primary key column of the `genre` table.